### PR TITLE
feat(api): implement audio transcription endpoint with OpenAI Whisper integration

### DIFF
--- a/audio-transcribe/src/main/java/com/audio/transcribe/TranscriptionController.java
+++ b/audio-transcribe/src/main/java/com/audio/transcribe/TranscriptionController.java
@@ -1,9 +1,49 @@
 package com.audio.transcribe;
+import org.springframework.ai.audio.transcription.AudioTranscriptionPrompt;
+import org.springframework.ai.audio.transcription.AudioTranscriptionResponse;
+import org.springframework.ai.openai.OpenAiAudioTranscriptionModel;
+import org.springframework.ai.openai.OpenAiAudioTranscriptionOptions;
+import org.springframework.ai.openai.api.OpenAiAudioApi;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+
+import static java.io.File.createTempFile;
 
 
-;
-
+@RestController
+@RequestMapping("/api/transcribe")
 
 public class TranscriptionController {
+    private final OpenAiAudioTranscriptionModel transcriptionModel;
+
+    public TranscriptionController(OpenAiAudioTranscriptionModel transcriptionModel) {
+        this.transcriptionModel = transcriptionModel;
+    }
+
+    @PostMapping
+    public ResponseEntity<String> transcribeAudio(@RequestParam("file") MultipartFile file) throws IOException {
+        File tempFile = createTempFile("audio", ".wav");
+        file.transferTo(tempFile);
+
+        OpenAiAudioTranscriptionOptions options = OpenAiAudioTranscriptionOptions.builder()
+                .responseFormat(OpenAiAudioApi.TranscriptResponseFormat.TEXT)
+                .language("en")
+                .temperature(0f)
+                .build();
+
+        FileSystemResource audioFile = new FileSystemResource(tempFile);
+
+        AudioTranscriptionPrompt prompt = new AudioTranscriptionPrompt(audioFile, options);
+        AudioTranscriptionResponse response = transcriptionModel.call(prompt);
+
+        tempFile.delete();
+        return new ResponseEntity<>(response.getResult().getOutput(), HttpStatus.OK);
+    }
 
 }

--- a/audio-transcribe/src/main/resources/application.properties
+++ b/audio-transcribe/src/main/resources/application.properties
@@ -1,1 +1,5 @@
 spring.application.name=audio-transcribe
+spring.ai.openai.api-key= ${OPENAI_API_KEY}
+spring.ai.openai.audio.transcription.base-url= https://api.openai.com
+spring.ai.openai.audio.transcription.options.model=whisper-1
+spring.ai.openai.audio.transcription.options.response-format=json


### PR DESCRIPTION
### Updated application properties


Added configuration for OpenAI Whisper transcription:

-       Base URL (https://api.openai.com/)

-       Model set to whisper-1

-       Response format set to json


### Added TranscriptionController

 Exposes POST /api/transcribe endpoint for uploading .wav audio files.

 Saves uploaded file as a temporary resource.

 Configures transcription options:

-       Response format: text

-       Language: English ("en")

-       Temperature: 0F

- Calls OpenAiAudioTranscriptionModel with generated prompt.

- Returns transcription result as HTTP 200 response.

- Deletes temporary file after processing.