### PR TITLE
feat(backend): add CORS configuration to allow frontend requests

### DIFF
--- a/audio-transcribe/src/main/java/com/audio/transcribe/WebConfig.java
+++ b/audio-transcribe/src/main/java/com/audio/transcribe/WebConfig.java
@@ -1,2 +1,18 @@
-package com.audio.transcribe;public class WebConfig {
+package com.audio.transcribe;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig  implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5174")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
 }


### PR DESCRIPTION
### Added

- WebConfig.java

       Introduced @Configuration class implementing WebMvcConfigurer.

       Overrode addCorsMappings to enable cross-origin requests from the frontend.
 

    **Configured**:

            Allowed origin: http://localhost:5173 (default Vite dev server).

            Allowed methods: GET, POST, PUT, DELETE, OPTIONS.

            Allowed credentials: true.


- Enables the React/Vite frontend (running on port 5173) to communicate with the Spring Boot backend API without being blocked by browser CORS policies.

- Establishes groundwork for full-stack integration and smooth local development.